### PR TITLE
feature: abstract the authentication methods

### DIFF
--- a/vita-cera-client/src/Renaissance/Client/Bz.hs
+++ b/vita-cera-client/src/Renaissance/Client/Bz.hs
@@ -15,35 +15,42 @@ import Auth.Token (AccessGrant, AccessToken)
 import Control.Monad.Trans.Except (ExceptT)
 import Data.Proxy (Proxy(..))
 import Data.Token (toText)
+import Data.Text (Text)
 import Data.UUID (UUID)
 import Network.HTTP.Client (Manager)
-import Servant.API ((:<|>) ((:<|>)))
+import Servant.API ((:<|>) ((:<|>)), Headers, NoContent)
 import Servant.Auth.Token.Api (TokenProtect, PostTokenRefreshReq)
-import Servant.Client (client, BaseUrl, ServantError, AuthenticateReq)
+import Servant.Client (client, BaseUrl, ServantError, AuthenticateReq, ClientM)
 
 import Renaissance.Api.Base
-import Renaissance.Api.Bz (TokenGetRouteBody, BzApi, WhoAmIResponse)
+import Renaissance.Api.Bz (TokenGetRouteBody, BzApi, WhoAmIResponse, WithAuthToken)
 
 bzApi :: Proxy BzApi
 bzApi = Proxy
 
-postAccountsNew :: Manager
+postAccountsNew :: Text
+                -> Manager
                 -> BaseUrl
-                -> ExceptT ServantError IO UUID
+                -> ClientM (WithAuthToken NoContent)
+
+postAuthDev :: Text
+            -> Manager
+            -> BaseUrl
+            -> ClientM (WithAuthToken NoContent)
 
 postTokenGet :: TokenGetRouteBody
                 -> Manager
                 -> BaseUrl
-                -> ExceptT ServantError IO AccessGrant
+                -> ClientM AccessGrant
 
 postTokenRefresh :: PostTokenRefreshReq
                  -> Manager
                  -> BaseUrl
-                 -> ExceptT ServantError IO AccessGrant
+                 -> ClientM AccessGrant
 
 getWhoAmI :: AuthenticateReq TokenProtect
           -> Manager
           -> BaseUrl
-          -> ExceptT ServantError IO WhoAmIResponse
+          -> ClientM WhoAmIResponse
 
-((postTokenGet :<|> postTokenRefresh) :<|> getWhoAmI) :<|> postAccountsNew = client bzApi
+((postTokenGet :<|> postTokenRefresh) :<|> getWhoAmI) :<|> (postAuthDev :<|> postAccountsNew) = client bzApi

--- a/vita-cera-client/vita-cera-client.cabal
+++ b/vita-cera-client/vita-cera-client.cabal
@@ -31,6 +31,7 @@ library
                      , vita-cera == 0.0.0
                      , auth-token
                      , servant-auth-token-api
+                     , text
                      , token
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/vita-cera/src/Renaissance/Api/Bz.hs
+++ b/vita-cera/src/Renaissance/Api/Bz.hs
@@ -6,13 +6,17 @@ module Renaissance.Api.Bz
   , ForeignBzApi
   , BzApi
   , BzPublicApi
+  , WithAuthToken
   ) where
 
 import Servant.API
 import Servant.Auth.Token.Api
-import Data.UUID
+import Data.UUID (UUID)
+import Data.Text (Text)
 
 import Renaissance.Api.Bz.Data
+
+type WithAuthToken a = Headers '[Header "authorization-token" AuthorizationToken] a
 
 type ForeignBzApi = ForeignAuthentApi TokenGetRouteBody WhoAmIResponse
                :<|> BzPublicApi
@@ -21,4 +25,6 @@ type ForeignBzApi = ForeignAuthentApi TokenGetRouteBody WhoAmIResponse
 type BzApi = AuthentApi TokenGetRouteBody WhoAmIResponse
         :<|> BzPublicApi
 
-type BzPublicApi = "accounts" :> "new" :> PostCreated '[JSON] UUID
+type BzPublicApi =
+       "accounts" :> "new" :> "dev" :> Capture "name" Text :> PostCreated '[JSON] (WithAuthToken NoContent)
+  :<|> "auth" :> "dev" :> Capture "name" Text :> PostAccepted '[JSON] (WithAuthToken NoContent)

--- a/vita-cera/src/Renaissance/Api/Bz/Data.hs
+++ b/vita-cera/src/Renaissance/Api/Bz/Data.hs
@@ -2,14 +2,24 @@
 
 module Renaissance.Api.Bz.Data where
 
+import Data.Token (fromText, Token)
+import Data.Token.Aeson
 import GHC.Generics
-import Data.Text (Text)
 import Data.Aeson
 import Data.UUID.Aeson
-import Data.UUID
+import Data.UUID (UUID)
+import Data.ByteString.Conversion.From
+
+data Authorization
+type AuthorizationToken = Token Authorization
+
+instance FromByteString (Token a) where
+    parser = do txt <- parser
+                return $ fromText txt
+
 
 data TokenGetRouteBody = TokenGetRouteBody
-                       { email :: Text }
+                       { authorizationToken :: AuthorizationToken }
   deriving (Generic)
 
 instance FromJSON TokenGetRouteBody

--- a/vita-cera/vita-cera.cabal
+++ b/vita-cera/vita-cera.cabal
@@ -34,7 +34,10 @@ library
                    , servant-auth-token-api
                    , auth-token
                    , text
+                   , bytestring-conversion
                    , aeson
+                   , token
+                   , token-aeson
                    , http-api-data
                    , time
                    , uuid


### PR DESCRIPTION
The idea is the following: we provide as many routes as there is authentication methods. For instance, `auth/google` for authenticate with a google account and `auth/dev` for development purposes. These routes returns an Authorization token, which later can be used by the client to get an access token.

Therefore, this PR prepares #15 but does not implement it.
